### PR TITLE
TablesAPI

### DIFF
--- a/src/DataValues.jl
+++ b/src/DataValues.jl
@@ -28,4 +28,12 @@ include("array/promotion.jl")
 
 # include("utils.jl")
 
+import TablesAPI
+TablesAPI.nondatavaluetype(::Type{DataValue{T}}) where {T} = Union{T, Missing}
+TablesAPI.unwrap(x::DataValue) = isna(x) ? missing : DataValues.unsafe_get(x)
+TablesAPI.datavaluetype(::Type{T}) where {T <: DataValue} = T
+TablesAPI.datavaluetype(::Type{Union{T, Missing}}) where {T} = DataValue{T}
+TablesAPI.datavaluetype(::Type{Missing}) = DataValue{Union{}}
+TablesAPI.scalarconvert(::Type{T}, ::Missing) where {T <: DataValue} = T()
+
 end


### PR DESCRIPTION
Move a few integration method definitions from Tables.jl at-require blocks to DataValues through new TablesAPI.jl package

This is a piece of overcoming the past sins of Tables.jl using Requires.jl as a low-level interface package (and hurting perf for downstream packages everywhere). The core Tables.jl API & helper functions are now defined in [TablesAPI.jl](https://github.com/JuliaData/TablesAPI.jl) which will only ever be empty generic function stubs. They are effectively "owned" by Tables.jl, which just means that Tables.jl will be in charge of defining the generic fallback definitions.

Note this is currently a ***draft*** PR because TablesAPI.jl is not yet registered and I'd still like to get feedback from the various parties affected (@nalimilan , @davidanthoff , etc.) on the best way forward.