### PR TITLE
resolve ambiguity when != between missing and NA

### DIFF
--- a/src/scalar/core.jl
+++ b/src/scalar/core.jl
@@ -125,6 +125,7 @@ Base.zero(x::DataValues.DataValue{T}) where {T<:Dates.Period}= DataValue{T}(zero
 ==(a::DataValue{Union{}}, b::DataValue{Union{}}) = true
 !=(a::DataValue{T},b::DataValue{Union{}}) where {T} = !isna(a)
 !=(a::DataValue{Union{}},b::DataValue{T}) where {T} = !isna(b)
+!=(a::DataValue{Union{}}, b::DataValue{Union{}}) = false
 
 # Strings
 

--- a/test/scalar/test_core.jl
+++ b/test/scalar/test_core.jl
@@ -10,6 +10,7 @@ using InteractiveUtils
 @test DataValue(missing) == NA
 @test DataValue{Int}(missing) == DataValue{Int}()
 @test convert(Missing, NA) === missing
+@test false == (DataValue(missing) != NA)
 
 end
 


### PR DESCRIPTION
I ran into this with the following code:

```julia
data = DataFrame(a=[missing, 1.0])
datam = DataFrame(a=[missing])

function f(d)
    @from i in d begin
        @where i.a != NA
        @select i
        @collect
    end
end
@show f(data)
@show f(datam)
```

The second call errors on the ambiguity.